### PR TITLE
Add $STATSD_ENABLED

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
-`0.0.1`_ (08-Apr-2021)
-----------------------
-- support for sending counters & timers to statsd over a TCP or UDP socket
+:tag:`Next release <0.0.1...main>`
+----------------------------------
+- Added :envvar:`STATSD_ENABLED` environment variable to disable the Tornado integration
 
-.. _0.0.1: https://github.com/sprockets/sprockets-statsd/compare/832f8af7...0.0.1
+:tag:`0.0.1 <832f8af7...0.0.1>` (08-Apr-2021)
+---------------------------------------------
+- Simple support for sending counters & timers to statsd over a TCP or UDP socket

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 Asynchronously send metrics to a statsd_ instance.
 
-|build| |coverage| |sonar| |docs| |source|
-
-.. COMMENTED OUT FOR THE TIME BEING
-   |docs| |download| |license|
+|build| |coverage| |sonar| |docs| |source| |download| |license|
 
 This library provides connectors to send metrics to a statsd_ instance using either TCP or UDP.
 
@@ -130,7 +127,7 @@ not connected to the server and will be sent in the order received when the task
 .. |download| image:: https://img.shields.io/pypi/pyversions/sprockets-statsd.svg?style=social
    :target: https://pypi.org/project/sprockets-statsd/
 .. |license| image:: https://img.shields.io/pypi/l/sprockets-statsd.svg?style=social
-   :target: https://github.com/sprockets/sprockets-statsd/blob/master/LICENSE.txt
+   :target: https://github.com/sprockets/sprockets-statsd/blob/master/LICENSE
 .. |sonar| image:: https://img.shields.io/sonar/quality_gate/sprockets_sprockets-statsd?server=https%3A%2F%2Fsonarcloud.io&style=social
    :target: https://sonarcloud.io/dashboard?id=sprockets_sprockets-statsd
 .. |source| image:: https://img.shields.io/badge/source-github.com-green.svg?style=social

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,5 +16,11 @@ intersphinx_mapping = {
     'tornado': ('https://www.tornadoweb.org/en/branch6.0/', None),
 }
 
+# https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
+extensions.append('sphinx.ext.extlinks')
+extlinks = {
+    'tag': ("https://github.com/sprockets/sprockets-statsd/compare/%s", "%s"),
+}
+
 # https://pypi.org/project/sphinx-autodoc-typehints/
 extensions.append('sphinx_autodoc_typehints')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,10 +3,10 @@ sprockets-statsd
 
 .. include:: ../README.rst
 
-Configuration
-=============
-The statsd connection is configured by the ``statsd`` application settings key.  The default values can be set by
-the following environment variables.
+Tornado configuration
+=====================
+The Tornado statsd connection is configured by the ``statsd`` application settings key.  The default values can be set
+by the following environment variables.
 
 .. envvar:: STATSD_HOST
 
@@ -25,6 +25,17 @@ the following environment variables.
 
    The IP protocol to use when connecting to the StatsD server.  You can specify either "tcp" or "udp".  The
    default is "tcp" if it not not configured.
+
+.. envvar:: STATSD_ENABLED
+
+   Define this variable and set it to a *falsy* value to **disable** the Tornado integration.  If you omit
+   this variable, then the connector is enabled.  The following values are considered *truthy*:
+
+   - non-zero integer
+   - case-insensitive match of ``yes``, ``true``, ``t``, or ``on``
+
+   All other values are considered *falsy*.  You only want to define this environment variables when you
+   want to explicitly disable an otherwise installed and configured connection.
 
 If you are using the Tornado helper clases, then you can fine tune the metric payloads and the connector by
 setting additional values in the ``statsd`` key of :attr:`tornado.web.Application.settings`.  See the
@@ -46,6 +57,9 @@ Tornado helpers
 
 Internals
 ---------
+.. autoclass:: sprockets_statsd.statsd.AbstractConnector
+   :members:
+
 .. autoclass:: sprockets_statsd.statsd.Processor
    :members:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ warning_is_error = 1
 
 [coverage:report]
 exclude_lines =
+    pass
     pragma: no cover
     raise NotImplementedError
 fail_under = 100


### PR DESCRIPTION
Defining this environment variable to a false value will disable the Tornado integration.  Instead of setting the connector to `None`, I decided to use a version of the object that does nothing.  This will make it possible to access the low-level `Connector` safely and avoid `NoneType` exceptions.