### PR TITLE
Detect sprockets.http and make use of it.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,8 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # sonar wants a "deep" clone
       - name: Install python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -42,6 +44,12 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           fail_ci_if_error: true
+      - name: Run sonarqube scan
+        if: ${{ matrix.python-version == '3.9' }}
+        uses: SonarSource/sonarcloud-github-action@v1.3
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
       - name: Save coverage report
         if: ${{ matrix.python-version == '3.9' }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,6 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # sonar wants a "deep" clone
       - name: Install python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -44,12 +42,6 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           fail_ci_if_error: true
-      - name: Run sonarqube scan
-        if: ${{ matrix.python-version == '3.9' }}
-        uses: SonarSource/sonarcloud-github-action@v1.3
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
       - name: Save coverage report
         if: ${{ matrix.python-version == '3.9' }}
         uses: actions/upload-artifact@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 :tag:`Next release <0.0.1...main>`
 ----------------------------------
 - Added :envvar:`STATSD_ENABLED` environment variable to disable the Tornado integration
+- Tornado application mixin automatically installs start/stop hooks if the application
+  quacks like a ``sprockets.http.app.Application``.
 
 :tag:`0.0.1 <832f8af7...0.0.1>` (08-Apr-2021)
 ---------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@
 - Added :envvar:`STATSD_ENABLED` environment variable to disable the Tornado integration
 - Tornado application mixin automatically installs start/stop hooks if the application
   quacks like a ``sprockets.http.app.Application``.
+- Limit logging when disconnected from statsd
 
 :tag:`0.0.1 <832f8af7...0.0.1>` (08-Apr-2021)
 ---------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ dev =
     flake8-import-order==0.18.1
     sphinx==3.5.2
     sphinx-autodoc-typehints==1.11.1
+    sprockets.http==2.2.0
     tornado>=5
     yapf==0.30.0
 readthedocs =

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -378,7 +378,7 @@ class ConnectorTests(ProcessorTestCase):
 
         # then overflow it a bunch of times
         overflow_count = self.connector._enqueue_log_guard.threshold * 5
-        for value in range(overflow_count):
+        for _ in range(overflow_count):
             self.connector.incr('counter')
         self.assertLess(self.connector.logger.warning.call_count,
                         overflow_count)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -3,6 +3,7 @@ import logging
 import socket
 import time
 import typing
+import unittest.mock
 
 import asynctest
 
@@ -203,6 +204,17 @@ class TCPProcessingTests(ProcessorTestCase):
         self.processor.queue.put_nowait(b'counter:1|c')
         await self.wait_for(self.statsd_server.message_received.acquire())
 
+    async def test_that_disconnected_logging_is_throttled(self):
+        self.statsd_server.close()
+        await self.statsd_server.wait_closed()
+
+        self.processor.logger = unittest.mock.Mock()
+        self.processor._connect_log_guard.threshold = 10
+        self.processor._reconnect_sleep = 0
+        while self.processor._connect_log_guard.counter < (20 + 1):
+            await asyncio.sleep(0)
+        self.assertLess(self.processor.logger.warning.call_count, 20)
+
 
 class UDPProcessingTests(ProcessorTestCase):
     ip_protocol = socket.IPPROTO_UDP
@@ -353,6 +365,23 @@ class ConnectorTests(ProcessorTestCase):
             await self.wait_for(self.statsd_server.message_received.acquire())
             self.assertEqual(f'counters.counter:{value}|c'.encode(),
                              self.statsd_server.metrics.pop(0))
+
+    async def test_that_queue_full_logging_is_throttled(self):
+        await self.connector.processor.stop()
+
+        self.connector.logger = unittest.mock.Mock()
+        self.connector._enqueue_log_guard.threshold = 10
+
+        # fill up the queue
+        for _ in range(self.connector.processor.queue.maxsize):
+            self.connector.incr('counter')
+
+        # then overflow it a bunch of times
+        overflow_count = self.connector._enqueue_log_guard.threshold * 5
+        for value in range(overflow_count):
+            self.connector.incr('counter')
+        self.assertLess(self.connector.logger.warning.call_count,
+                        overflow_count)
 
 
 class ConnectorOptionTests(ProcessorTestCase):


### PR DESCRIPTION
This PR changes the `Application` class to detect when the `on_start_callbacks` and `on_shutdown_callback` attributes of `sprockets.http.app.Application` are available and register the `start_statsd` and `stop_statsd` for you.  Simply including `Application` in the inheritance chain before `sprockets.http.app.Application` will automatically initialize the statsd connector as described in the readme.