### PR TITLE
Add support for python-statsd alike timer method.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Next release
 ------------
 - Added ``Connector.timer`` method (addresses :issue:`8`)
+- Implement ``Timer`` abstraction from python-statsd
 
 :tag:`0.1.0 <0.0.1...0.1.0>` (10-May-2021)
 ------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+Next release
+------------
+- Added ``Connector.timer`` method (addresses :issue:`8`)
+
 :tag:`0.1.0 <0.0.1...0.1.0>` (10-May-2021)
 ------------------------------------------
 - Added :envvar:`STATSD_ENABLED` environment variable to disable the Tornado integration

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@ Next release
 ------------
 - Added ``Connector.timer`` method (addresses :issue:`8`)
 - Implement ``Timer`` abstraction from python-statsd
+- ``Connector.timing`` now accepts :class:`datetime.timedelta` instances in addition
+  to :class:`float` instances
 
 :tag:`0.1.0 <0.0.1...0.1.0>` (10-May-2021)
 ------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -36,15 +36,29 @@ metric to send and the task consumes the internal queue when it is connected.
 The following convenience methods are available.  You can also call ``inject_metric`` for complete control over
 the payload.
 
-+--------------+--------------------------------------+
-| ``incr``     | Increment a counter metric           |
-+--------------+--------------------------------------+
-| ``decr``     | Decrement a counter metric           |
-+--------------+--------------------------------------+
-| ``gauge``    | Adjust or set a gauge metric         |
-+--------------+--------------------------------------+
-| ``timing``   | Append a duration to a timer metric  |
-+--------------+--------------------------------------+
++--------------+--------------------------------------------------------------+
+| ``incr``     | Increment a counter metric                                   |
++--------------+--------------------------------------------------------------+
+| ``decr``     | Decrement a counter metric                                   |
++--------------+--------------------------------------------------------------+
+| ``gauge``    | Adjust or set a gauge metric                                 |
++--------------+--------------------------------------------------------------+
+| ``timer``    | Append a duration to a timer metric using a context manager  |
++--------------+--------------------------------------------------------------+
+| ``timing``   | Append a duration to a timer metric                          |
++--------------+--------------------------------------------------------------+
+
+If you are a `python-statsd`_ user, then the method names should look very familiar.  That is quite intentional.
+I like the interface and many others do as well.  There is one very very important difference though -- the
+``timing`` method takes the duration as the number of **seconds** as a :class:`float` instead of the number of
+milliseconds.
+
+.. warning::
+
+   If you are accustomed to using `python-statsd`_, be aware that the ``timing`` method expects the number of
+   seconds as a :class:`float` instead of the number of milliseconds.
+
+.. _python-statsd: https://statsd.readthedocs.io/en/latest/
 
 Tornado helpers
 ===============

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ intersphinx_mapping = {
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
 extensions.append('sphinx.ext.extlinks')
 extlinks = {
+    'issue': ("https://github.com/sprockets/sprockets-statsd/issues/%s", "#%s"),
     'tag': ("https://github.com/sprockets/sprockets-statsd/compare/%s", "%s"),
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Reference
 
 .. autoclass:: sprockets_statsd.statsd.Connector
    :members:
+   :inherited-members: incr, decr, gauge, timer, timing
 
 Tornado helpers
 ---------------
@@ -61,6 +62,9 @@ Internals
    :members:
 
 .. autoclass:: sprockets_statsd.statsd.Processor
+   :members:
+
+.. autoclass:: sprockets_statsd.statsd.Timer
    :members:
 
 .. autoclass:: sprockets_statsd.statsd.StatsdProtocol

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,16 +38,16 @@ tornado =
 dev =
     asynctest==0.13.0
     coverage==5.5
-    flake8==3.8.4
+    flake8==3.9.2
     flake8-import-order==0.18.1
-    sphinx==3.5.2
-    sphinx-autodoc-typehints==1.11.1
+    sphinx==4.1.1
+    sphinx-autodoc-typehints==1.12.0
     sprockets.http==2.2.0
     tornado>=5
-    yapf==0.30.0
+    yapf==0.31.0
 readthedocs =
-    sphinx==3.5.2
-    sphinx-autodoc-typehints==1.11.1
+    sphinx==4.1.1
+    sphinx-autodoc-typehints==1.12.1
     tornado>=5
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ project_urls:
 author = Dave Shawley
 author_email = daveshawley@gmail.com
 classifiers =
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Natural Language :: English

--- a/sprockets_statsd/statsd.py
+++ b/sprockets_statsd/statsd.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import logging
 import socket
 import time
@@ -174,13 +175,16 @@ class AbstractConnector:
             payload = str(value)
         self.inject_metric(f'gauges.{path}', payload, 'g')
 
-    def timing(self, path: str, seconds: float) -> None:
+    def timing(self, path: str,
+               seconds: typing.Union[float, datetime.timedelta]) -> None:
         """Send a timer metric.
 
         :param path: timer to append a value to
         :param seconds: number of **seconds** to record
 
         """
+        if isinstance(seconds, datetime.timedelta):
+            seconds = seconds.total_seconds()
         self.inject_metric(f'timers.{path}', str(seconds * 1000.0), 'ms')
 
     def timer(self, path) -> Timer:

--- a/sprockets_statsd/statsd.py
+++ b/sprockets_statsd/statsd.py
@@ -1,6 +1,8 @@
 import asyncio
+import contextlib
 import logging
 import socket
+import time
 import typing
 
 
@@ -107,6 +109,20 @@ class AbstractConnector:
 
         """
         self.inject_metric(f'timers.{path}', str(seconds * 1000.0), 'ms')
+
+    @contextlib.contextmanager
+    def timer(self, path):
+        """Send a timer metric using a context manager.
+
+        :param path: timer to append the measured time to
+
+        """
+        start = time.time()
+        try:
+            yield
+        finally:
+            fini = time.time()
+            self.timing(path, max(fini, start) - start)
 
 
 class Connector(AbstractConnector):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import logging
 import socket
 import time
@@ -332,6 +333,13 @@ class ConnectorTests(ProcessorTestCase):
 
     async def test_sending_timer(self):
         secs = 12.34
+        self.connector.timing('simple.timer', secs)
+        await self.wait_for(self.statsd_server.message_received.acquire())
+        self.assert_metrics_equal(self.statsd_server.metrics[0],
+                                  'timers.simple.timer', 12340.0, 'ms')
+
+    async def test_sending_timer_using_timedelta(self):
+        secs = datetime.timedelta(seconds=12, milliseconds=340)
         self.connector.timing('simple.timer', secs)
         await self.wait_for(self.statsd_server.message_received.acquire())
         self.assert_metrics_equal(self.statsd_server.metrics[0],

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -350,7 +350,7 @@ class ConnectorTests(ProcessorTestCase):
                 'sprockets_statsd.statsd.time.time') as time_function:
             time_function.side_effect = [10.0, 22.345]
             with self.connector.timer('some.timer'):
-                pass
+                pass  # exercising context manager
             self.assertEqual(2, time_function.call_count)
 
         await self.wait_for(self.statsd_server.message_received.acquire())
@@ -362,7 +362,7 @@ class ConnectorTests(ProcessorTestCase):
                 'sprockets_statsd.statsd.time.time') as time_function:
             time_function.side_effect = [10.001, 10.000]
             with self.connector.timer('some.timer'):
-                pass
+                pass  # exercising context manager
             self.assertEqual(2, time_function.call_count)
 
         await self.wait_for(self.statsd_server.message_received.acquire())
@@ -541,10 +541,10 @@ class ConnectorTimerTests(ProcessorTestCase):
     async def test_that_timer_can_be_reused(self):
         timer = self.connector.timer('whatever')
         with timer:
-            pass
+            pass  # exercising context manager
         await self.wait_for(self.statsd_server.message_received.acquire())
         self.assertTrue(self.statsd_server.message_received.locked())
 
         with timer:
-            pass
+            pass  # exercising context manager
         await self.wait_for(self.statsd_server.message_received.acquire())


### PR DESCRIPTION
This PR addresses #8 by implementing the [python-statsd Timer abstraction](https://statsd.readthedocs.io/en/v3.3/timing.html) in full including the `Timer` class.  I also added support for `datetime.timdelta` instances in addition to a `float` number of seconds in the `timing` method.