### PR TITLE
Increase default queued metrics limit from 1,000 to 1,000,000

### DIFF
--- a/sprockets_statsd/statsd.py
+++ b/sprockets_statsd/statsd.py
@@ -496,7 +496,7 @@ class Processor:
                  host: str,
                  port: int = 8125,
                  ip_protocol: int = socket.IPPROTO_TCP,
-                 max_queue_size: int = 1000,
+                 max_queue_size: int = 1000000,
                  reconnect_sleep: float = 1.0,
                  wait_timeout: float = 0.1) -> None:
         super().__init__()


### PR DESCRIPTION
So I unintentionally lost metrics by mixing the async sprockets-statsd library with blocking sync code. The statsd client was completely blocked and never had a chance to publish metrics. Although that was purely an error of my own making, I temporarily overrode the max_queue_size in my app as an intermediate fix.

I'm thinking upping the default in the library is relatively sane as it shouldn't increase memory consumption too much in even the worst cases. 

---
Understanding that asyncio.Queue stores items in a collections.deque instance, this is the memory usage difference between the current default of 1,000 and the new default of 1,000,000.

1,000 metrics is roughly 8.9KB
```
>>> d = collections.deque()
>>> for _ in range(1000):
...   d.append(b'applications.this-is-my-service.development.errors.rabbitmq.unroutable:1|c')
...
>>> sys.getsizeof(d)
9072
```

1,000,000 metrics is roughly 7.9MB
```
>>> d = collections.deque()
>>> for _ in range(1000000):
...   d.append(b'applications.this-is-my-service.development.errors.rabbitmq.unroutable:1|c')
...
>>> sys.getsizeof(d)
8250624
```